### PR TITLE
Add support for `omitempty` tag option

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -11,7 +11,7 @@ me_home=$(cd "$me_home" && pwd)
 DLV="dlv"
 
 # parse arguments
-args=$(getopt d $*)
+args=$(getopt dcv $*)
 set -- $args
 for i; do
   case "$i"
@@ -19,13 +19,19 @@ for i; do
     -d)
       debug="true";
       shift;;
+    -c)
+      other_flags="$other_flags -cover";
+      shift;;
+    -v)
+      other_flags="$other_flags -v";
+      shift;;
     --)
       shift; break;;
   esac
 done
 
 if [ ! -z "$debug" ]; then
-  ETC="${me_home}/v1/internal/fixtures" "$DLV" test $* -- -test.v
+  ETC="${me_home}/v1/internal/fixtures" "$DLV" test $* -- $other_flags
 else
-  ETC="${me_home}/v1/internal/fixtures" go test -v $*
+  ETC="${me_home}/v1/internal/fixtures" go test$other_flags $*
 fi

--- a/v1/entity/entity_test.go
+++ b/v1/entity/entity_test.go
@@ -8,6 +8,7 @@ type testEntity struct {
 	embedEntity
 	A string `db:"z,pk"`
 	D int    // ignored
+	E int    `db:"e,omitempty"`
 }
 
 type multiPKEntity struct {

--- a/v1/entity/generator_test.go
+++ b/v1/entity/generator_test.go
@@ -15,10 +15,10 @@ func TestGeneratorInsert(t *testing.T) {
 		Args   []interface{}
 	}{
 		{
-			testEntity{embedEntity{"BBB"}, "AAA", 999},
+			testEntity{embedEntity{"BBB"}, "AAA", 999, 0},
 			"some_table",
-			"INSERT INTO some_table (y, z) VALUES ($1, $2)",
-			[]interface{}{"BBB", "AAA"},
+			"INSERT INTO some_table (e, y, z) VALUES ($1, $2, $3)",
+			[]interface{}{nil, "BBB", "AAA"},
 		},
 	}
 	gen := &Generator{NewFieldMapper(), true}
@@ -39,21 +39,21 @@ func TestGeneratorUpdate(t *testing.T) {
 		Args    []interface{}
 	}{
 		{
-			testEntity{embedEntity{"BBB"}, "AAA", 999},
+			testEntity{embedEntity{"BBB"}, "AAA", 999, 0},
 			"some_table",
 			[]string{"z", "y"},
 			"UPDATE some_table SET y = $1, z = $2 WHERE z = $3",
 			[]interface{}{"BBB", "AAA", "AAA"},
 		},
 		{
-			testEntity{embedEntity{"BBB"}, "AAA", 999},
+			testEntity{embedEntity{"BBB"}, "AAA", 999, 0},
 			"some_table",
 			nil,
-			"UPDATE some_table SET y = $1, z = $2 WHERE z = $3",
-			[]interface{}{"BBB", "AAA", "AAA"},
+			"UPDATE some_table SET e = $1, y = $2, z = $3 WHERE z = $4",
+			[]interface{}{nil, "BBB", "AAA", "AAA"},
 		},
 		{
-			testEntity{embedEntity{"BBB"}, "AAA", 999},
+			testEntity{embedEntity{"BBB"}, "AAA", 999, 0},
 			"some_table",
 			[]string{"z"},
 			"UPDATE some_table SET z = $1 WHERE z = $2",
@@ -91,7 +91,7 @@ func TestGeneratorSelect(t *testing.T) {
 				Cols: []string{"z"},
 				Vals: []interface{}{"AAA"},
 			},
-			"SELECT y, z FROM some_table WHERE z = $1",
+			"SELECT e, y, z FROM some_table WHERE z = $1",
 			[]interface{}{"AAA"},
 		},
 		{

--- a/v1/entity/mapper.go
+++ b/v1/entity/mapper.go
@@ -2,6 +2,7 @@ package entity
 
 import (
 	"reflect"
+	"runtime"
 	"sync"
 
 	"github.com/bww/go-dbx/v1"
@@ -9,6 +10,10 @@ import (
 )
 
 const Tag = "db"
+const (
+	optionPrimaryKey = "pk"
+	optionOmitEmpty  = "omitempty"
+)
 
 var (
 	initOnce      sync.Once
@@ -32,6 +37,21 @@ func NewFieldMapper() *FieldMapper {
 	}
 }
 
+func (m *FieldMapper) KeysForType(typ reflect.Type) []string {
+	var cols []string
+	x := m.TypeMap(typ)
+	for k, f := range x.Names {
+		if isExplicitMapping(f) {
+			if f.Options != nil {
+				if _, ok := f.Options[optionPrimaryKey]; ok {
+					cols = append(cols, k)
+				}
+			}
+		}
+	}
+	return cols
+}
+
 func (m *FieldMapper) Keys(entity interface{}) (*Values, error) {
 	var kcols []string
 	var kvals []reflect.Value
@@ -46,7 +66,7 @@ func (m *FieldMapper) Keys(entity interface{}) (*Values, error) {
 	for k, f := range x.Names {
 		if isExplicitMapping(f) {
 			if f.Options != nil {
-				if _, ok := f.Options["pk"]; ok {
+				if _, ok := f.Options[optionPrimaryKey]; ok {
 					kcols = append(kcols, k)
 					kvals = append(kvals, reflectx.FieldByIndexes(e, f.Index))
 				}
@@ -55,21 +75,6 @@ func (m *FieldMapper) Keys(entity interface{}) (*Values, error) {
 	}
 
 	return &Values{kcols, kvals}, nil
-}
-
-func (m *FieldMapper) KeysForType(typ reflect.Type) []string {
-	var cols []string
-	x := m.TypeMap(typ)
-	for k, f := range x.Names {
-		if isExplicitMapping(f) {
-			if f.Options != nil {
-				if _, ok := f.Options["pk"]; ok {
-					cols = append(cols, k)
-				}
-			}
-		}
-	}
-	return cols
 }
 
 func (m *FieldMapper) ColumnsForType(typ reflect.Type) []string {
@@ -102,10 +107,16 @@ func (m *FieldMapper) Columns(entity interface{}) (*Columns, *Columns) {
 			}
 
 			vcols = append(vcols, k)
-			vvals = append(vvals, x)
+			if f.Options == nil {
+				vvals = append(vvals, x)
+			} else if _, ok := f.Options[optionOmitEmpty]; ok && isEmptyValue(v) {
+				vvals = append(vvals, nil)
+			} else {
+				vvals = append(vvals, x)
+			}
 
 			if f.Options != nil {
-				if _, ok := f.Options["pk"]; ok {
+				if _, ok := f.Options[optionPrimaryKey]; ok {
 					kcols = append(kcols, k)
 					kvals = append(kvals, x)
 				}
@@ -114,6 +125,71 @@ func (m *FieldMapper) Columns(entity interface{}) (*Columns, *Columns) {
 	}
 
 	return &Columns{kcols, kvals}, &Columns{vcols, vvals}
+}
+
+// TraversalsByName returns a slice of int slices which represent the struct
+// traversals for each mapped name and a slice of bools which indicates whether
+// each such traversal is omit-empty.  Panics if t is not a struct or Indirectable
+// to a struct.  Returns empty int slice for each name not found.
+func (m *FieldMapper) TraversalsByName(t reflect.Type, names []string) ([][]int, []bool) {
+	r := make([][]int, 0, len(names))
+	o := make([]bool, 0, len(names))
+	m.TraversalsByNameFunc(t, names, func(_ int, i []int, e bool) error {
+		if i == nil {
+			r = append(r, []int{})
+		} else {
+			r = append(r, i)
+		}
+		o = append(o, e)
+		return nil
+	})
+	return r, o
+}
+
+// TraversalsByNameFunc traverses the mapped names and calls fn with the index of
+// each name and the struct traversal represented by that name. Panics if t is not
+// a struct or Indirectable to a struct. Returns the first error returned by fn or nil.
+func (m *FieldMapper) TraversalsByNameFunc(t reflect.Type, names []string, fn func(int, []int, bool) error) error {
+	t = reflectx.Deref(t)
+	mustBe(t, reflect.Struct)
+	tm := m.TypeMap(t)
+	for i, name := range names {
+		fi, ok := tm.Names[name]
+		if !ok {
+			if err := fn(i, nil, false); err != nil {
+				return err
+			}
+		} else {
+			var oe bool
+			if fi.Options != nil {
+				_, oe = fi.Options[optionOmitEmpty]
+			}
+			if err := fn(i, fi.Index, oe); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+type kinder interface {
+	Kind() reflect.Kind
+}
+
+func mustBe(v kinder, expected reflect.Kind) {
+	if k := v.Kind(); k != expected {
+		panic(&reflect.ValueError{Method: methodName(), Kind: k})
+	}
+}
+
+func methodName() string {
+	pc, _, _, _ := runtime.Caller(2)
+	f := runtime.FuncForPC(pc)
+	if f != nil {
+		return f.Name()
+	} else {
+		return "unknown method"
+	}
 }
 
 const ignoreName = "__ignore_field__"

--- a/v1/entity/mapper_test.go
+++ b/v1/entity/mapper_test.go
@@ -16,10 +16,16 @@ func TestFieldMapper(t *testing.T) {
 		Values  []interface{}
 	}{
 		{
-			testEntity{embedEntity{"BBB"}, "AAA", 999},
+			testEntity{embedEntity{"BBB"}, "AAA", 999, 0},
 			[]string{"z"},
-			[]string{"y", "z"},
-			[]interface{}{"BBB", "AAA"},
+			[]string{"e", "y", "z"},
+			[]interface{}{nil, "BBB", "AAA"},
+		},
+		{
+			testEntity{embedEntity{"BBB"}, "AAA", 999, 111},
+			[]string{"z"},
+			[]string{"e", "y", "z"},
+			[]interface{}{111, "BBB", "AAA"},
 		},
 	}
 	for _, e := range tests {

--- a/v1/entity/util.go
+++ b/v1/entity/util.go
@@ -1,0 +1,24 @@
+package entity
+
+import (
+	"reflect"
+)
+
+// from encoding/json
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}

--- a/v1/errors.go
+++ b/v1/errors.go
@@ -10,4 +10,6 @@ var (
 	ErrInvalidField    = errors.New("Invalid field")
 	ErrInvalidKeyCount = errors.New("Invalid primary key count")
 	ErrNotAPointer     = errors.New("Not a pointer")
+	ErrNotAStruct      = errors.New("Not a struct")
+	ErrMissingField    = errors.New("Missing field")
 )

--- a/v1/internal/fixtures/migrations/001_up_base.sql
+++ b/v1/internal/fixtures/migrations/001_up_base.sql
@@ -16,3 +16,13 @@ create table test_entity_r_another_entity (
   x     varchar(64)     not null references another_entity,
   primary key(a, x)
 );
+
+create table omitempty_entity (
+  z     varchar(64)     primary key not null,
+  a     varchar(64),
+  b     integer,
+  c     bigint,
+  d     boolean,
+  e     double precision,
+  f     bytea
+);

--- a/v1/internal/fixtures/migrations/001_up_base.sql
+++ b/v1/internal/fixtures/migrations/001_up_base.sql
@@ -2,7 +2,8 @@
 create table test_entity (
   a     varchar(64)     primary key not null,
   b     varchar(64),
-  c     integer
+  c     integer,
+  e     integer
 );
 
 create table another_entity (

--- a/v1/persist/persist.go
+++ b/v1/persist/persist.go
@@ -182,7 +182,7 @@ func (p *persister) selectMany(ent interface{}, val reflect.Value, cols []string
 		return dbx.ErrNotAPointer
 	}
 
-	raws, err := p.Context.Query(sql, args...)
+	raws, err := p.Context.Queryx(sql, args...)
 	if err != nil {
 		return err
 	}

--- a/v1/persist/persist.go
+++ b/v1/persist/persist.go
@@ -82,7 +82,9 @@ func (p *persister) Fetch(table string, ent, id interface{}) error {
 		Vals: []interface{}{id},
 	})
 
-	err := p.Context.QueryRowx(sql, args...).StructScan(ent)
+	raw := p.Context.QueryRowx(sql, args...)
+	row := newRow(raw, p.fm)
+	err := row.ScanStruct(ent)
 	if err == dbsql.ErrNoRows {
 		return dbx.ErrNotFound
 	} else if err != nil {
@@ -155,7 +157,9 @@ func (p *persister) Select(ent interface{}, query string, args ...interface{}) e
 
 func (p *persister) selectOne(ent interface{}, val reflect.Value, cols []string, sql string, args []interface{}) error {
 
-	err := p.Context.QueryRowx(sql, args...).StructScan(ent)
+	raw := p.Context.QueryRowx(sql, args...)
+	row := newRow(raw, p.fm)
+	err := row.ScanStruct(ent)
 	if err != nil {
 		return err
 	}

--- a/v1/persist/persist.go
+++ b/v1/persist/persist.go
@@ -178,11 +178,12 @@ func (p *persister) selectMany(ent interface{}, val reflect.Value, cols []string
 		return dbx.ErrNotAPointer
 	}
 
-	rows, err := p.Context.Queryx(sql, args...)
+	raws, err := p.Context.Query(sql, args...)
 	if err != nil {
 		return err
 	}
 
+	rows := newRows(raws, p.fm)
 	eval := reflect.Indirect(val)
 	etype := eval.Type().Elem()
 	ctype := etype
@@ -202,7 +203,7 @@ func (p *persister) selectMany(ent interface{}, val reflect.Value, cols []string
 	for rows.Next() {
 		elem := reflect.New(ctype)
 		eint := elem.Interface()
-		err := rows.StructScan(eint)
+		err := rows.ScanStruct(eint)
 		if err != nil {
 			return err
 		}

--- a/v1/persist/persist.go
+++ b/v1/persist/persist.go
@@ -188,6 +188,12 @@ func (p *persister) selectMany(ent interface{}, val reflect.Value, cols []string
 	}
 
 	rows := newRows(raws, p.fm)
+	defer func() {
+		if rows != nil {
+			rows.Close()
+		}
+	}()
+
 	eval := reflect.Indirect(val)
 	etype := eval.Type().Elem()
 	ctype := etype
@@ -221,6 +227,11 @@ func (p *persister) selectMany(ent interface{}, val reflect.Value, cols []string
 			elem = reflect.Indirect(elem)
 		}
 		eval = reflect.Append(eval, elem)
+	}
+
+	err, rows = rows.Close(), nil
+	if err != nil {
+		return err
 	}
 
 	reflect.Indirect(val).Set(eval)

--- a/v1/persist/persist_test.go
+++ b/v1/persist/persist_test.go
@@ -153,11 +153,12 @@ func TestPersist(t *testing.T) {
 	}
 
 	var eb testEntity
-	err = db.QueryRowx(`SELECT a, b, c FROM `+testTable+` WHERE a = $1`, e1.A).StructScan(&eb)
+	err = db.QueryRowx(`SELECT a, b, c, e FROM `+testTable+` WHERE a = $1`, e2.A).StructScan(&eb)
 	if assert.Nil(t, err, fmt.Sprint(err)) {
-		assert.Equal(t, e1.A, eb.A)
-		assert.Equal(t, e1.B, eb.B)
-		assert.Equal(t, e1.C, eb.C)
+		assert.Equal(t, e2.A, eb.A)
+		assert.Equal(t, e2.B, eb.B)
+		assert.Equal(t, e2.C, eb.C)
+		assert.Equal(t, e2.E, eb.E)
 	}
 
 	var ec testEntity
@@ -166,6 +167,16 @@ func TestPersist(t *testing.T) {
 		assert.Equal(t, e1.A, ec.A)
 		assert.Equal(t, e1.B, ec.B)
 		assert.Equal(t, e1.C, ec.C)
+		assert.Equal(t, e1.E, ec.E)
+	}
+
+	var ed testEntity
+	err = pst.Fetch(testTable, &ed, e2.A)
+	if assert.Nil(t, err, fmt.Sprint(err)) {
+		assert.Equal(t, e2.A, ed.A)
+		assert.Equal(t, e2.B, ed.B)
+		assert.Equal(t, e2.C, ed.C)
+		assert.Equal(t, e2.E, ed.E)
 	}
 
 	err = pst.Fetch(testTable, &ec, "THIS IS NOT A VALID IDENT, BRAH")
@@ -178,12 +189,12 @@ func TestPersist(t *testing.T) {
 		assert.Equal(t, 2, count)
 	}
 
-	var ed []*testEntity
-	err = pst.Select(&ed, `SELECT {*} FROM `+testTable+` ORDER BY c`)
+	var ef []*testEntity
+	err = pst.Select(&ef, `SELECT {*} FROM `+testTable+` ORDER BY c`)
 	if assert.Nil(t, err, fmt.Sprint(err)) {
-		if assert.Len(t, ed, 2) {
-			assert.Equal(t, e1, ed[0])
-			assert.Equal(t, e2, ed[1])
+		if assert.Len(t, ef, 2) {
+			assert.Equal(t, e1, ef[0])
+			assert.Equal(t, e2, ef[1])
 		}
 	}
 

--- a/v1/persist/persist_test.go
+++ b/v1/persist/persist_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	// "github.com/bww/go-dbx/v1"
+	"github.com/bww/go-dbx/v1"
 	"github.com/bww/go-dbx/v1/entity"
 	"github.com/bww/go-dbx/v1/persist/ident"
 	"github.com/bww/go-dbx/v1/persist/registry"
@@ -160,18 +160,18 @@ func TestPersist(t *testing.T) {
 		assert.Equal(t, e1.C, eb.C)
 	}
 
-	// var ec testEntity
-	// err = pst.Fetch(testTable, &ec, e1.A)
-	// if assert.Nil(t, err, fmt.Sprint(err)) {
-	// 	assert.Equal(t, e1.A, ec.A)
-	// 	assert.Equal(t, e1.B, ec.B)
-	// 	assert.Equal(t, e1.C, ec.C)
-	// }
+	var ec testEntity
+	err = pst.Fetch(testTable, &ec, e1.A)
+	if assert.Nil(t, err, fmt.Sprint(err)) {
+		assert.Equal(t, e1.A, ec.A)
+		assert.Equal(t, e1.B, ec.B)
+		assert.Equal(t, e1.C, ec.C)
+	}
 
-	// err = pst.Fetch(testTable, &ec, "THIS IS NOT A VALID IDENT, BRAH")
-	// if assert.NotNil(t, err, "Expected an error") {
-	// 	assert.Equal(t, dbx.ErrNotFound, err)
-	// }
+	err = pst.Fetch(testTable, &ec, "THIS IS NOT A VALID IDENT, BRAH")
+	if assert.NotNil(t, err, "Expected an error") {
+		assert.Equal(t, dbx.ErrNotFound, err)
+	}
 
 	count, err := pst.Count(`SELECT COUNT(*) FROM ` + testTable)
 	if assert.Nil(t, err, fmt.Sprint(err)) {

--- a/v1/persist/persist_test.go
+++ b/v1/persist/persist_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/bww/go-dbx/v1"
+	// "github.com/bww/go-dbx/v1"
 	"github.com/bww/go-dbx/v1/entity"
 	"github.com/bww/go-dbx/v1/persist/ident"
 	"github.com/bww/go-dbx/v1/persist/registry"
@@ -39,6 +39,7 @@ type testEntity struct {
 	*DontUseThisExportedEntity
 	A string `db:"a,pk"`
 	C int    `db:"c"`
+	E int    `db:"e,omitempty"`
 	D []*anotherEntity
 }
 
@@ -129,6 +130,7 @@ func TestPersist(t *testing.T) {
 			B: "Never is this the value of B",
 		},
 		C: 999,
+		E: 111,
 		D: []*anotherEntity{
 			{Z: 111},
 			{Z: 222},
@@ -158,18 +160,18 @@ func TestPersist(t *testing.T) {
 		assert.Equal(t, e1.C, eb.C)
 	}
 
-	var ec testEntity
-	err = pst.Fetch(testTable, &ec, e1.A)
-	if assert.Nil(t, err, fmt.Sprint(err)) {
-		assert.Equal(t, e1.A, ec.A)
-		assert.Equal(t, e1.B, ec.B)
-		assert.Equal(t, e1.C, ec.C)
-	}
+	// var ec testEntity
+	// err = pst.Fetch(testTable, &ec, e1.A)
+	// if assert.Nil(t, err, fmt.Sprint(err)) {
+	// 	assert.Equal(t, e1.A, ec.A)
+	// 	assert.Equal(t, e1.B, ec.B)
+	// 	assert.Equal(t, e1.C, ec.C)
+	// }
 
-	err = pst.Fetch(testTable, &ec, "THIS IS NOT A VALID IDENT, BRAH")
-	if assert.NotNil(t, err, "Expected an error") {
-		assert.Equal(t, dbx.ErrNotFound, err)
-	}
+	// err = pst.Fetch(testTable, &ec, "THIS IS NOT A VALID IDENT, BRAH")
+	// if assert.NotNil(t, err, "Expected an error") {
+	// 	assert.Equal(t, dbx.ErrNotFound, err)
+	// }
 
 	count, err := pst.Count(`SELECT COUNT(*) FROM ` + testTable)
 	if assert.Nil(t, err, fmt.Sprint(err)) {

--- a/v1/persist/persist_test.go
+++ b/v1/persist/persist_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/bww/go-dbx/v1/persist/registry"
 	"github.com/bww/go-dbx/v1/test"
 	"github.com/bww/go-util/env"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -265,7 +264,6 @@ func TestPersistOmitEmpty(t *testing.T) {
 	}
 	err = db.QueryRow(`SELECT z, a, b, c, d, e, f FROM `+omitemptyTable+` WHERE z = $1`, e1.Z).Scan(r1...)
 	if assert.Nil(t, err, fmt.Sprint(err)) {
-		spew.Dump(r1)
 		assert.Equal(t, e1.Z, x1.Z)
 		assert.Equal(t, nil, x1.A)
 		assert.Equal(t, nil, x1.B)

--- a/v1/persist/rows.go
+++ b/v1/persist/rows.go
@@ -6,8 +6,56 @@ import (
 
 	"github.com/bww/go-dbx/v1"
 	"github.com/bww/go-dbx/v1/entity"
+	"github.com/jmoiron/sqlx"
 	"github.com/jmoiron/sqlx/reflectx"
 )
+
+type Row struct {
+	*sqlx.Row
+	mapper *entity.FieldMapper
+}
+
+func newRow(r *sqlx.Row, m *entity.FieldMapper) *Row {
+	return &Row{Row: r, mapper: m}
+}
+
+func (r *Row) ScanStruct(dest interface{}) error {
+	v := reflect.ValueOf(dest)
+	if v.Kind() != reflect.Ptr {
+		return dbx.ErrNotAPointer
+	}
+
+	v = v.Elem()
+	columns, err := r.Columns()
+	if err != nil {
+		return err
+	}
+
+	m := r.mapper
+	fields, omits := m.TraversalsByName(v.Type(), columns)
+	temps := make([]bool, len(columns))
+	values := make([]interface{}, len(columns))
+
+	// initialize for scanning
+	err = fieldsByTraversal(v, fields, omits, temps, values, true)
+	if err != nil {
+		return err
+	}
+
+	// scan out values, potentically including indirect placeholders for omittable fields
+	err = r.Scan(values...)
+	if err != nil {
+		return err
+	}
+
+	// copy over valid omittable values to their fields
+	err = finalizeFields(v, fields, temps, values)
+	if err != nil {
+		return err
+	}
+
+	return r.Err()
+}
 
 type Rows struct {
 	*sql.Rows
@@ -52,37 +100,46 @@ func (r *Rows) ScanStruct(dest interface{}) error {
 		return err
 	}
 
-	// copy over valid omittable values to their fields. this check method uses potentially
-	// more iterations in exchange for constant allocations. this tradeoff may not make sense
-	for i, e := range r.temps {
-		if e {
-			t := reflect.Indirect(reflect.ValueOf(r.values[i]))
-			if !t.IsNil() {
-				f := reflectx.FieldByIndexes(v, r.fields[i])
-				f.Set(reflect.Indirect(t))
-			}
-		}
+	// copy over valid omittable values to their fields
+	err = finalizeFields(v, r.fields, r.temps, r.values)
+	if err != nil {
+		return err
 	}
 
 	return r.Err()
 }
 
-func fieldsByTraversal(v reflect.Value, traversals [][]int, omits, temps []bool, values []interface{}, ptrs bool) error {
+func fieldsByTraversal(v reflect.Value, fields [][]int, omits, temps []bool, values []interface{}, ptrs bool) error {
 	v = reflect.Indirect(v)
 	if v.Kind() != reflect.Struct {
 		return dbx.ErrNotAStruct
 	}
-	for i, traversal := range traversals {
-		if len(traversal) == 0 {
+	for i, field := range fields {
+		if len(field) == 0 {
 			values[i], temps[i] = new(interface{}), false
 		} else {
-			f := reflectx.FieldByIndexes(v, traversal)
+			f := reflectx.FieldByIndexes(v, field)
 			if omits[i] && ptrs && f.Kind() != reflect.Ptr {
 				values[i], temps[i] = reflect.New(reflect.PtrTo(f.Type())).Interface(), true
 			} else if ptrs {
 				values[i], temps[i] = f.Addr().Interface(), false
 			} else {
 				values[i], temps[i] = f.Interface(), false
+			}
+		}
+	}
+	return nil
+}
+
+func finalizeFields(v reflect.Value, fields [][]int, temps []bool, values []interface{}) error {
+	for i, e := range temps {
+		if e {
+			t := reflect.Indirect(reflect.ValueOf(values[i]))
+			f := reflectx.FieldByIndexes(v, fields[i])
+			if !t.IsNil() {
+				f.Set(reflect.Indirect(t))
+			} else { // explicitly set the zero value if the value is missing
+				f.Set(reflect.Zero(f.Type()))
 			}
 		}
 	}

--- a/v1/persist/rows.go
+++ b/v1/persist/rows.go
@@ -1,7 +1,6 @@
 package persist
 
 import (
-	"database/sql"
 	"reflect"
 
 	"github.com/bww/go-dbx/v1"
@@ -58,7 +57,7 @@ func (r *Row) ScanStruct(dest interface{}) error {
 }
 
 type Rows struct {
-	*sql.Rows
+	*sqlx.Rows
 	mapper *entity.FieldMapper
 	fields [][]int
 	omits  []bool
@@ -66,7 +65,7 @@ type Rows struct {
 	values []interface{}
 }
 
-func newRows(r *sql.Rows, m *entity.FieldMapper) *Rows {
+func newRows(r *sqlx.Rows, m *entity.FieldMapper) *Rows {
 	return &Rows{Rows: r, mapper: m}
 }
 


### PR DESCRIPTION
A mapped field that uses the `omitempty` option will have similar handling to the stdlib json marshaler. This allows a struct to use `NULL` for zero values in the database without using a pointer in the struct. Specifically:

- When persisting, a struct field with the `omitempty` option that has a zero value will be set to `NULL` in the database (or however the db engine interprets `nil`),
- When querying, a struct field with the `omitempty` option whose value is `NULL` in the database will be set to its zero value in the struct.