### PR TITLE
Fixing a bug where connections could be leaked from `Select`/`QueryRowx`

### DIFF
--- a/etc/migrations/001_up_base.sql
+++ b/etc/migrations/001_up_base.sql
@@ -29,3 +29,8 @@ create table third_entity (
   h     uuid,
   i     varchar(26)
 );
+
+create table fourth_entity (
+  x     varchar(64)     primary key not null,
+  z     integer
+);

--- a/v1/entity/mapper.go
+++ b/v1/entity/mapper.go
@@ -154,7 +154,10 @@ func (m *FieldMapper) TraversalsByName(t reflect.Type, names []string) ([][]int,
 // a struct or Indirectable to a struct. Returns the first error returned by fn or nil.
 func (m *FieldMapper) TraversalsByNameFunc(t reflect.Type, names []string, fn func(int, []int, bool) error) error {
 	t = reflectx.Deref(t)
-	mustBe(t, reflect.Struct)
+	err := mustBe(t, reflect.Struct)
+	if err != nil {
+		return err
+	}
 	tm := m.TypeMap(t)
 	for i, name := range names {
 		fi, ok := tm.Names[name]
@@ -204,10 +207,11 @@ type kinder interface {
 	Kind() reflect.Kind
 }
 
-func mustBe(v kinder, expected reflect.Kind) {
+func mustBe(v kinder, expected reflect.Kind) error {
 	if k := v.Kind(); k != expected {
-		panic(&reflect.ValueError{Method: methodName(), Kind: k})
+		return &reflect.ValueError{Method: methodName(), Kind: k}
 	}
+	return nil
 }
 
 func methodName() string {

--- a/v1/persist/persist_test.go
+++ b/v1/persist/persist_test.go
@@ -434,3 +434,17 @@ func TestPersistFetchAndStoreInATightLoop(t *testing.T) {
 	}
 
 }
+
+func TestInvalidParamInSelectOneDoesntLeakConns(t *testing.T) {
+	db := test.DB()
+	pst := New(db, entity.NewFieldMapper(), registry.New(), ident.AlphaNumeric(32))
+	var err error
+
+	for i := 0; i < 10; i++ {
+		var invalid int // invalid destination type
+		err = pst.Select(&invalid, `SELECT {*} FROM `+fourthTable+` WHERE x = $1`, fmt.Sprint(i))
+		assert.NotNil(t, err, "Expected an error")
+	}
+
+	// if we don't hang forever, we have succeeded
+}

--- a/v1/persist/rows.go
+++ b/v1/persist/rows.go
@@ -53,8 +53,7 @@ func (r *Row) ScanStruct(dest interface{}) error {
 	// Scan out values, potentically including indirect placeholders for omittable fields;
 	// NOTE THAT Scan() MUST BE INVOKED AS CALLING SCAN IS WHAT CLOSES THE UNDERLYING ROWS
 	// THAT ARE USED BY sqlx.
-	err = r.Scan(values...)
-	scanned = true
+	err, scanned = r.Scan(values...), true
 	if err != nil {
 		return err
 	}

--- a/v1/persist/rows.go
+++ b/v1/persist/rows.go
@@ -23,7 +23,7 @@ func (r *Row) ScanStruct(dest interface{}) error {
 	var scanned bool
 	defer func() {
 		if !scanned {
-			fmt.Printf("dbx: Row was not closed due to an internal error; forcing closed now: %v\n", err)
+			fmt.Printf("dbx: Row was not closed due to a parameter error; you are not using DBX correctly: %v\n", err)
 			r.Row.Scan() // scan to force sqlx to close its rows if we haven't done so already
 		}
 	}()

--- a/v1/persist/rows.go
+++ b/v1/persist/rows.go
@@ -1,6 +1,7 @@
 package persist
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/bww/go-dbx/v1"
@@ -18,6 +19,15 @@ func newRow(r *sqlx.Row, m *entity.FieldMapper) *Row {
 }
 
 func (r *Row) ScanStruct(dest interface{}) error {
+	var err error
+	var scanned bool
+	defer func() {
+		if !scanned {
+			fmt.Printf("dbx: Row was not closed due to an internal error; forcing closed now: %v\n", err)
+			r.Row.Scan() // scan to force sqlx to close its rows if we haven't done so already
+		}
+	}()
+
 	v := reflect.ValueOf(dest)
 	if v.Kind() != reflect.Ptr {
 		return dbx.ErrNotAPointer
@@ -40,8 +50,11 @@ func (r *Row) ScanStruct(dest interface{}) error {
 		return err
 	}
 
-	// scan out values, potentically including indirect placeholders for omittable fields
+	// Scan out values, potentically including indirect placeholders for omittable fields;
+	// NOTE THAT Scan() MUST BE INVOKED AS CALLING SCAN IS WHAT CLOSES THE UNDERLYING ROWS
+	// THAT ARE USED BY sqlx.
 	err = r.Scan(values...)
+	scanned = true
 	if err != nil {
 		return err
 	}

--- a/v1/test/test.go
+++ b/v1/test/test.go
@@ -69,7 +69,7 @@ func setup(conf *Config) error {
 		fmt.Println("--> INIT ", dsn)
 	}
 
-	sharedDB, err = dbx.New(dsn)
+	sharedDB, err = dbx.New(dsn, dbx.WithMaxOpenConns(5), dbx.WithMaxIdleConns(5))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It's possible for `Select` to leak DB connections if an error causes the routine to return before the row is scanned. This should never happen in practice, it's essentially a bug on the caller side: wrong parameter type or invalid configuration. But if it does happen, we should not leak connections in this package.

This update ensures the connection is closed (by scanning nothing, there is no explicit close method exposed) even in the case where we abort early.